### PR TITLE
Fix side.getOpposite() was called twice in EnergyUtils.java

### DIFF
--- a/src/main/java/de/maxhenkel/corelib/energy/EnergyUtils.java
+++ b/src/main/java/de/maxhenkel/corelib/energy/EnergyUtils.java
@@ -59,7 +59,7 @@ public class EnergyUtils {
      */
     @Nullable
     public static IEnergyStorage getEnergyStorageOffset(LevelAccessor world, BlockPos pos, Direction side) {
-        return getEnergyStorage(world, pos.relative(side), side.getOpposite());
+        return getEnergyStorage(world, pos.relative(side), side);
     }
 
 }


### PR DESCRIPTION
side.getOpposite() will be called if the getEnergyStorageOffset() is used, because it calls getEnergyStorage() internally which also calls side.getOpposite().
Therefore the original direction would be used instead of the opposite.